### PR TITLE
Add configure_git and return_app_token options

### DIFF
--- a/.github/workflows/tests-ssh.yml
+++ b/.github/workflows/tests-ssh.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: webfactory/ssh-agent@v0.2.0
+      - uses: webfactory/ssh-agent@v0.5.2
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For enterprise environments we recommend using a GitHub app per organization wit
 
 ### Inputs
 
-* `actions_list` - **REQUIRED**: List of private actions to checkout. Must be a JSON array and each entry must match the format owner/repo@ref.  May be an empty array if no actions are required.
+* `actions_list` - **OPTIONAL**: List of private actions to checkout. Must be a JSON array and each entry must match the format owner/repo@ref.  May be an empty array if no actions are required.
 * `checkout_base_path` - **OPTIONAL**: Where to checkout the custom actions. It uses `./.github/actions` as default path
 * `return_app_token` - **OPTIONAL**: If set to `true` then an output variable called `app-token` will be set that can be used for basic auth to github by subsequent steps (only works with Github Apps as the authentication method)
 * `configure_git` - **OPTIONAL**: If set to `true` then `git config` is executed to grant subsequent steps access to other private repos using the ssh or Github App token.

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Enables using private actions on a workflow"
 inputs:
   actions_list:
     description: List of private actions to checkout. Must be a JSON array and each entry must mutch the format owner/repo@ref
-    required: true
+    required: false
     default: '[]'
   checkout_base_path:
     description: Where to checkout the custom actions

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ inputs:
   actions_list:
     description: List of private actions to checkout. Must be a JSON array and each entry must mutch the format owner/repo@ref
     required: true
+    default: '[]'
   checkout_base_path:
     description: Where to checkout the custom actions
     required: true
@@ -17,9 +18,19 @@ inputs:
   app_private_key:
     description: The app private key to authenticate with a GitHub app
     required: false
+  return_app_token:
+    description: Sets app-token as an output if set to "true"
+    required: false
+  configure_git:
+    description: Configures git to continue to use the ssh key or app token after the action exits if set to "true"
+    required: false
+outputs:
+  app-token:
+    description: transient token generated if a Github app was supplied
 runs:
   using: "node12"
   main: "dist/index.js"
+  post: "dist/cleanup/index.js"
 branding:
-  icon: 'download-cloud'  
+  icon: 'download-cloud'
   color: 'yellow'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -1,0 +1,612 @@
+module.exports =
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 351:
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+"use strict";
+
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(278);
+/**
+ * Commands
+ *
+ * Command Format:
+ *   ::name key=value,key=value::message
+ *
+ * Examples:
+ *   ::warning::This is the message
+ *   ::set-env name=MY_VAR::some value
+ */
+function issueCommand(command, properties, message) {
+    const cmd = new Command(command, properties, message);
+    process.stdout.write(cmd.toString() + os.EOL);
+}
+exports.issueCommand = issueCommand;
+function issue(name, message = '') {
+    issueCommand(name, {}, message);
+}
+exports.issue = issue;
+const CMD_STRING = '::';
+class Command {
+    constructor(command, properties, message) {
+        if (!command) {
+            command = 'missing.command';
+        }
+        this.command = command;
+        this.properties = properties;
+        this.message = message;
+    }
+    toString() {
+        let cmdStr = CMD_STRING + this.command;
+        if (this.properties && Object.keys(this.properties).length > 0) {
+            cmdStr += ' ';
+            let first = true;
+            for (const key in this.properties) {
+                if (this.properties.hasOwnProperty(key)) {
+                    const val = this.properties[key];
+                    if (val) {
+                        if (first) {
+                            first = false;
+                        }
+                        else {
+                            cmdStr += ',';
+                        }
+                        cmdStr += `${key}=${escapeProperty(val)}`;
+                    }
+                }
+            }
+        }
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+        return cmdStr;
+    }
+}
+function escapeData(s) {
+    return utils_1.toCommandValue(s)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
+}
+function escapeProperty(s) {
+    return utils_1.toCommandValue(s)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A')
+        .replace(/:/g, '%3A')
+        .replace(/,/g, '%2C');
+}
+//# sourceMappingURL=command.js.map
+
+/***/ }),
+
+/***/ 186:
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const command_1 = __webpack_require__(351);
+const file_command_1 = __webpack_require__(717);
+const utils_1 = __webpack_require__(278);
+const os = __importStar(__webpack_require__(87));
+const path = __importStar(__webpack_require__(622));
+/**
+ * The code to exit an action
+ */
+var ExitCode;
+(function (ExitCode) {
+    /**
+     * A code indicating that the action was successful
+     */
+    ExitCode[ExitCode["Success"] = 0] = "Success";
+    /**
+     * A code indicating that the action was a failure
+     */
+    ExitCode[ExitCode["Failure"] = 1] = "Failure";
+})(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
+//-----------------------------------------------------------------------
+// Variables
+//-----------------------------------------------------------------------
+/**
+ * Sets env variable for this action and future actions in the job
+ * @param name the name of the variable to set
+ * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function exportVariable(name, val) {
+    const convertedVal = utils_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
+    }
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
+}
+exports.exportVariable = exportVariable;
+/**
+ * Registers a secret which will get masked from logs
+ * @param secret value of the secret
+ */
+function setSecret(secret) {
+    command_1.issueCommand('add-mask', {}, secret);
+}
+exports.setSecret = setSecret;
+/**
+ * Prepends inputPath to the PATH (for this action and future actions)
+ * @param inputPath
+ */
+function addPath(inputPath) {
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        file_command_1.issueCommand('PATH', inputPath);
+    }
+    else {
+        command_1.issueCommand('add-path', {}, inputPath);
+    }
+    process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
+}
+exports.addPath = addPath;
+/**
+ * Gets the value of an input.  The value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string
+ */
+function getInput(name, options) {
+    const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
+    if (options && options.required && !val) {
+        throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return val.trim();
+}
+exports.getInput = getInput;
+/**
+ * Sets the value of an output.
+ *
+ * @param     name     name of the output to set
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setOutput(name, value) {
+    command_1.issueCommand('set-output', { name }, value);
+}
+exports.setOutput = setOutput;
+/**
+ * Enables or disables the echoing of commands into stdout for the rest of the step.
+ * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+ *
+ */
+function setCommandEcho(enabled) {
+    command_1.issue('echo', enabled ? 'on' : 'off');
+}
+exports.setCommandEcho = setCommandEcho;
+//-----------------------------------------------------------------------
+// Results
+//-----------------------------------------------------------------------
+/**
+ * Sets the action status to failed.
+ * When the action exits it will be with an exit code of 1
+ * @param message add error issue message
+ */
+function setFailed(message) {
+    process.exitCode = ExitCode.Failure;
+    error(message);
+}
+exports.setFailed = setFailed;
+//-----------------------------------------------------------------------
+// Logging Commands
+//-----------------------------------------------------------------------
+/**
+ * Gets whether Actions Step Debug is on or not
+ */
+function isDebug() {
+    return process.env['RUNNER_DEBUG'] === '1';
+}
+exports.isDebug = isDebug;
+/**
+ * Writes debug message to user log
+ * @param message debug message
+ */
+function debug(message) {
+    command_1.issueCommand('debug', {}, message);
+}
+exports.debug = debug;
+/**
+ * Adds an error issue
+ * @param message error issue message. Errors will be converted to string via toString()
+ */
+function error(message) {
+    command_1.issue('error', message instanceof Error ? message.toString() : message);
+}
+exports.error = error;
+/**
+ * Adds an warning issue
+ * @param message warning issue message. Errors will be converted to string via toString()
+ */
+function warning(message) {
+    command_1.issue('warning', message instanceof Error ? message.toString() : message);
+}
+exports.warning = warning;
+/**
+ * Writes info to log with console.log.
+ * @param message info message
+ */
+function info(message) {
+    process.stdout.write(message + os.EOL);
+}
+exports.info = info;
+/**
+ * Begin an output group.
+ *
+ * Output until the next `groupEnd` will be foldable in this group
+ *
+ * @param name The name of the output group
+ */
+function startGroup(name) {
+    command_1.issue('group', name);
+}
+exports.startGroup = startGroup;
+/**
+ * End an output group.
+ */
+function endGroup() {
+    command_1.issue('endgroup');
+}
+exports.endGroup = endGroup;
+/**
+ * Wrap an asynchronous function call in a group.
+ *
+ * Returns the same type as the function itself.
+ *
+ * @param name The name of the group
+ * @param fn The function to wrap in the group
+ */
+function group(name, fn) {
+    return __awaiter(this, void 0, void 0, function* () {
+        startGroup(name);
+        let result;
+        try {
+            result = yield fn();
+        }
+        finally {
+            endGroup();
+        }
+        return result;
+    });
+}
+exports.group = group;
+//-----------------------------------------------------------------------
+// Wrapper action state
+//-----------------------------------------------------------------------
+/**
+ * Saves state for current action, the state can only be retrieved by this action's post job execution.
+ *
+ * @param     name     name of the state to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function saveState(name, value) {
+    command_1.issueCommand('save-state', { name }, value);
+}
+exports.saveState = saveState;
+/**
+ * Gets the value of an state set by this action's main execution.
+ *
+ * @param     name     name of the state to get
+ * @returns   string
+ */
+function getState(name) {
+    return process.env[`STATE_${name}`] || '';
+}
+exports.getState = getState;
+//# sourceMappingURL=core.js.map
+
+/***/ }),
+
+/***/ 717:
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+"use strict";
+
+// For internal use, subject to change.
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(__webpack_require__(747));
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(278);
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+exports.issueCommand = issueCommand;
+//# sourceMappingURL=file-command.js.map
+
+/***/ }),
+
+/***/ 278:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+exports.toCommandValue = toCommandValue;
+//# sourceMappingURL=utils.js.map
+
+/***/ }),
+
+/***/ 759:
+/***/ ((module) => {
+
+const repoRegex = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)(@([A-Za-z0-9_.-]+))?$/
+const convertActionToCloneCommand = (cloneDir, action, cloneUrlBuilder) => {
+  const match = repoRegex.exec(action)
+  // Validate the format
+  if (!match) throw new Error(`The action ${action} does not match with the (org|owner)/repo[@branch|@tag] format`)
+
+  const params = {
+    owner: match[1],
+    repo: match[2],
+    ref: match[4]
+  }
+  // Validate owner and repo
+  if (!params.owner || !params.repo) throw new Error(`The action ${action} doesn't seem to contain a valid owner or repo`)
+
+  const defaultCommand = 'git clone --depth=1'
+  const branchCommand = params.ref ? `--single-branch --branch ${params.ref}` : ''
+  const cloneUrl = cloneUrlBuilder(params)
+  return `${defaultCommand} ${branchCommand} ${cloneUrl} ${cloneDir}/${params.repo}`
+}
+
+module.exports = {
+  convertActionToCloneCommand
+}
+
+
+/***/ }),
+
+/***/ 18:
+/***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
+
+const {
+  error,
+  getInput,
+  setFailed
+} = __webpack_require__(186)
+const {
+  cleanupSSH
+} = __webpack_require__(368)
+
+const run = async () => {
+  try {
+    const appId = getInput('app_id')
+    const configGit = getInput('configure_git') === 'true'
+
+    if (!appId && configGit) {
+      cleanupSSH()
+    }
+  } catch (e) {
+    error(e)
+    setFailed(e.message)
+  }
+}
+
+run()
+
+
+/***/ }),
+
+/***/ 368:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+const { execFileSync, execSync } = __webpack_require__(129)
+const fs = __webpack_require__(747)
+const {
+  info,
+  exportVariable
+} = __webpack_require__(186)
+
+const { convertActionToCloneCommand } = __webpack_require__(759)
+const sshHomePath = `${process.env.HOME}/.ssh`
+const sshHomeSetup = () => {
+  info('SSH > Creating SSH home folder')
+  fs.mkdirSync(sshHomePath, { recursive: true })
+  info('SSH > Configuring known_hosts file')
+  execSync(`ssh-keyscan -H github.com >> ${sshHomePath}/known_hosts`)
+}
+
+const sshAgentStart = (exportEnv) => {
+  info('SSH > Starting the SSH agent')
+  const sshAgentOutput = execFileSync('ssh-agent')
+  const lines = sshAgentOutput.toString().split('\n')
+  for (const lineNumber in lines) {
+    const matches = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(lines[lineNumber])
+    if (matches && matches.length > 0) {
+      process.env[matches[1]] = matches[2]
+      if (exportEnv) {
+        exportVariable(matches[1], matches[2])
+        info(`SSH > Export ${matches[1]} = ${matches[2]}`)
+      }
+    }
+  }
+}
+
+const addPrivateKey = (privateKey) => {
+  info('SSH > Adding the private key')
+  privateKey.split(/(?=-----BEGIN)/).forEach(function (key) {
+    execSync('ssh-add -', { input: key.trim() + '\n' })
+  })
+  execSync('ssh-add -l', { stdio: 'inherit' })
+}
+
+const sshSetup = (privateKey, exportEnv) => {
+  sshHomeSetup()
+  sshAgentStart(exportEnv)
+  addPrivateKey(privateKey)
+}
+
+const configureSSHGit = () => {
+  const command = 'git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"'
+  info(`App > ${command}`)
+  execSync(command)
+}
+
+const cloneWithSSH = (basePath, action) => {
+  const command = convertActionToCloneCommand(basePath, action, (params) =>
+    `git@github.com:${params.owner}/${params.repo}.git`
+  )
+  info(`SSH > ${command}`)
+  execSync(command)
+}
+
+const cleanupSSH = () => {
+  if (process.env.SSH_AGENT_PID) {
+    info('SSH > Killing the ssh-agent')
+    /* eslint no-template-curly-in-string: "off" */
+    execSync('kill ${SSH_AGENT_PID}', { stdio: 'inherit' })
+  }
+}
+
+module.exports = {
+  sshSetup,
+  cloneWithSSH,
+  cleanupSSH,
+  configureSSHGit
+}
+
+
+/***/ }),
+
+/***/ 129:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("child_process");
+
+/***/ }),
+
+/***/ 747:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("fs");
+
+/***/ }),
+
+/***/ 87:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("os");
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("path");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		if(__webpack_module_cache__[moduleId]) {
+/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	// module exports must be returned from runtime so entry inlining is disabled
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(18);
+/******/ })()
+;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "format": "standard --fix",
-    "build": "ncc build src/index.js"
+    "build": "ncc build src/index.js && ncc build src/cleanup.js -o dist/cleanup"
   },
   "keywords": [],
   "author": "",
@@ -24,5 +24,8 @@
     "ignore": [
       "/dist/*.js"
     ]
+  },
+  "volta": {
+    "node": "12.22.1"
   }
 }

--- a/src/cleanup.js
+++ b/src/cleanup.js
@@ -1,0 +1,24 @@
+const {
+  error,
+  getInput,
+  setFailed
+} = require('@actions/core')
+const {
+  cleanupSSH
+} = require('./ssh-setup')
+
+const run = async () => {
+  try {
+    const appId = getInput('app_id')
+    const configGit = getInput('configure_git') === 'true'
+
+    if (!appId && configGit) {
+      cleanupSSH()
+    }
+  } catch (e) {
+    error(e)
+    setFailed(e.message)
+  }
+}
+
+run()

--- a/src/github-app-setup.js
+++ b/src/github-app-setup.js
@@ -51,6 +51,12 @@ async function obtainAppToken (id, privateKeyInput) {
   }
 }
 
+const configureAppGit = (token) => {
+  const command = `git config --global url."https://x-access-token:${token}@github.com/".insteadOf "https://github.com/"`
+  info(`App > ${command}`)
+  execSync(command)
+}
+
 const cloneWithApp = (basePath, action, token) => {
   const command = convertActionToCloneCommand(basePath, action, (params) =>
     `https://x-access-token:${token}@github.com/${params.owner}/${params.repo}.git`
@@ -61,5 +67,6 @@ const cloneWithApp = (basePath, action, token) => {
 
 module.exports = {
   obtainAppToken,
-  cloneWithApp
+  cloneWithApp,
+  configureAppGit
 }


### PR DESCRIPTION
Transparently allow subsequent steps to gain access to the authenticated
method's private repos by running `git configure` using the generated
app token, or passing through access to the ssh agent

Useful for builds that need cross-repo access to complete without
adding additional steps.

Also add an optional output for the generated token that can be used with subsequent steps.