### PR TITLE
Bump node12->16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ outputs:
   app-token:
     description: transient token generated if a Github app was supplied
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
   post: "dist/cleanup/index.js"
 branding:


### PR DESCRIPTION
This is causing deprecation warnings (and next year will result in the action not working):
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

> `node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: daspn/private-actions-checkout@v2`
