### PR TITLE
Fix #37 - Bump node + deps to fix deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ outputs:
   app-token:
     description: transient token generated if a Github app was supplied
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
   post: "dist/cleanup/index.js"
 branding:

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@actions/core": "^1.2.6",
-    "@actions/github": "^4.0.0",
-    "@octokit/auth-app": "^3.6.1",
-    "https-proxy-agent": "^5.0.0",
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1",
+    "@octokit/auth-app": "^4.0.7",
+    "https-proxy-agent": "^5.0.1",
     "is-base64": "^1.1.0"
   },
   "devDependencies": {
@@ -27,6 +27,6 @@
     ]
   },
   "volta": {
-    "node": "12.22.1"
+    "node": "16.16.0"
   }
 }


### PR DESCRIPTION
Fixes #37 by updating node and dependencies:
 * Node 12 is end-of-support
 * `set-output` and friends are also on the way out