### PR TITLE
Use node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ outputs:
   app-token:
     description: transient token generated if a Github app was supplied
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
   post: "dist/cleanup/index.js"
 branding:


### PR DESCRIPTION
Node 16 is deprecated:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/